### PR TITLE
fix: do not raise an exception if 8bit on cpu

### DIFF
--- a/alpaca-lora/finetune.py
+++ b/alpaca-lora/finetune.py
@@ -323,12 +323,7 @@ def train(
         train_val = data["train"].train_test_split(
             test_size=val_set_size, shuffle=True, seed=42
         )
-        train_data = (
-            train_val["train"]
-            .shuffle()
-            .select(range(int(0.05 * len(train_val["train"]))))
-            .map(generate_and_tokenize_prompt)
-        )
+        train_data = train_val["train"].shuffle().map(generate_and_tokenize_prompt)
         val_data = train_val["test"].shuffle().map(generate_and_tokenize_prompt)
     else:
         train_data = data["train"].shuffle().map(generate_and_tokenize_prompt)


### PR DESCRIPTION
We have one parameter to change the quantisation behaviour: `load_in_4bit`. This default to `false`. In that case we set `load_in_8bit` to `True`.  However, none of the quantisation work on CPU, therefore we disable quantisation for CPU. This commit makes sure that we only raise an exception for the CPU 4bit combination and not the CPU 8bit combination. Otherwise the CI will always fail. 

It is a bit of an ugly workaround, alternative is to have two variables for 8bit and 4bit. The disadvantage of this is that we only need this flexibility for CI. During training and inference we would always use one of the two quantisations. 